### PR TITLE
Add modular book analysis scripts

### DIFF
--- a/clustering_analysis.py
+++ b/clustering_analysis.py
@@ -1,0 +1,89 @@
+import csv
+import math
+import random
+from collections import defaultdict
+
+
+def load_books(path='Books.csv'):
+    books = []
+    with open(path, newline='', encoding='utf-8') as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            books.append(row)
+    return books
+
+
+def to_int(value):
+    return int(value) if value and value.isdigit() else None
+
+
+def to_float(value):
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def normalize(vals):
+    m = min(vals)
+    M = max(vals)
+    if M == m:
+        return [0.0]*len(vals)
+    return [(v-m)/(M-m) for v in vals]
+
+
+def kmeans_cluster(books, k=3, iterations=10):
+    samples = []
+    for b in books:
+        p = to_int(b['pages'])
+        r = to_float(b['average_rating']) if b['average_rating'] != 'No rating' else None
+        rc = to_int(b['ratings_count'])
+        lang = b['language']
+        genre = b['genre']
+        if None not in (p, r, rc) and lang and genre:
+            samples.append({'pages': p, 'rating': r, 'ratings_count': rc, 'language': lang, 'genre': genre})
+    if len(samples) < k:
+        return []
+    langs = {s['language'] for s in samples}
+    genres = {s['genre'] for s in samples}
+    lang_map = {l: i for i, l in enumerate(sorted(langs))}
+    genre_map = {g: i for i, g in enumerate(sorted(genres))}
+    for s in samples:
+        s['language'] = lang_map[s['language']]
+        s['genre'] = genre_map[s['genre']]
+    pages_norm = normalize([s['pages'] for s in samples])
+    rating_norm = normalize([s['rating'] for s in samples])
+    rc_norm = normalize([s['ratings_count'] for s in samples])
+    for s, pn, rn, cn in zip(samples, pages_norm, rating_norm, rc_norm):
+        s['pages'] = pn
+        s['rating'] = rn
+        s['ratings_count'] = cn
+    centroids = random.sample(samples, k)
+    for _ in range(iterations):
+        clusters = [[] for _ in range(k)]
+        for s in samples:
+            distances = [math.dist([s['pages'], s['rating'], s['ratings_count'], s['language'], s['genre']],
+                                   [c['pages'], c['rating'], c['ratings_count'], c['language'], c['genre']])
+                         for c in centroids]
+            idx = distances.index(min(distances))
+            clusters[idx].append(s)
+        new_centroids = []
+        for cluster in clusters:
+            if not cluster:
+                new_centroids.append(random.choice(samples))
+                continue
+            mean = {}
+            for key in ['pages', 'rating', 'ratings_count', 'language', 'genre']:
+                mean[key] = sum(s[key] for s in cluster) / len(cluster)
+            new_centroids.append(mean)
+        centroids = new_centroids
+    return [len(c) for c in clusters]
+
+
+def main():
+    books = load_books()
+    print('Cluster sizes:', kmeans_cluster(books, k=3))
+
+
+if __name__ == '__main__':
+    main()

--- a/eda_analysis.py
+++ b/eda_analysis.py
@@ -1,0 +1,60 @@
+import csv
+from collections import Counter
+import statistics
+
+
+def load_books(path='Books.csv'):
+    books = []
+    with open(path, newline='', encoding='utf-8') as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            books.append(row)
+    return books
+
+
+def to_int(value):
+    return int(value) if value and value.isdigit() else None
+
+
+def page_distribution(books):
+    pages = [to_int(b['pages']) for b in books if to_int(b['pages']) is not None]
+    if not pages:
+        return {}
+    stats = {
+        'count': len(pages),
+        'min': min(pages),
+        'max': max(pages),
+        'mean': round(statistics.mean(pages), 2),
+        'median': statistics.median(pages)
+    }
+    return stats
+
+
+def distribution_by_field(books, field, top_n=10):
+    counter = Counter(b[field] for b in books if b[field])
+    return counter.most_common(top_n)
+
+
+def publication_year_distribution(books):
+    years = []
+    for b in books:
+        date = b['published_date']
+        if date:
+            year = date.split('-')[0]
+            if year.isdigit():
+                years.append(int(year))
+    return Counter(years)
+
+
+def main():
+    books = load_books()
+    print('Page distribution:', page_distribution(books))
+    print('Top genres:', distribution_by_field(books, 'genre'))
+    print('Top languages:', distribution_by_field(books, 'language'))
+    print('Top publishers:', distribution_by_field(books, 'publisher'))
+    years = publication_year_distribution(books)
+    print('Publication years sample:', list(years.items())[:10])
+
+
+if __name__ == '__main__':
+    main()

--- a/popularity_analysis.py
+++ b/popularity_analysis.py
@@ -1,0 +1,68 @@
+import csv
+import math
+from collections import Counter
+
+
+def load_books(path='Books.csv'):
+    books = []
+    with open(path, newline='', encoding='utf-8') as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            books.append(row)
+    return books
+
+
+def to_int(value):
+    return int(value) if value and value.isdigit() else None
+
+
+def to_float(value):
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def most_popular_books(books, top_n=10):
+    valid = [b for b in books if b['ratings_count'].isdigit()]
+    sorted_books = sorted(valid, key=lambda b: int(b['ratings_count']), reverse=True)
+    return [(b['title'], int(b['ratings_count'])) for b in sorted_books[:top_n]]
+
+
+def pages_vs_popularity_corr(books):
+    pairs = []
+    for b in books:
+        pages = to_int(b['pages'])
+        rc = to_int(b['ratings_count'])
+        if pages is not None and rc is not None:
+            pairs.append((pages, rc))
+    n = len(pairs)
+    if n == 0:
+        return None
+    mean_x = sum(p for p, _ in pairs) / n
+    mean_y = sum(rc for _, rc in pairs) / n
+    num = sum((p-mean_x)*(rc-mean_y) for p, rc in pairs)
+    den_x = math.sqrt(sum((p-mean_x)**2 for p, _ in pairs))
+    den_y = math.sqrt(sum((rc-mean_y)**2 for _, rc in pairs))
+    return num / (den_x * den_y) if den_x and den_y else None
+
+
+def top_rated_books(books, top_n=10):
+    valid = []
+    for b in books:
+        rating = to_float(b['average_rating']) if b['average_rating'] != 'No rating' else None
+        if rating is not None:
+            valid.append((rating, b['title']))
+    valid.sort(reverse=True)
+    return [(title, rating) for rating, title in valid[:top_n]]
+
+
+def main():
+    books = load_books()
+    print('Most popular books:', most_popular_books(books))
+    print('Pages vs popularity correlation:', pages_vs_popularity_corr(books))
+    print('Top rated books:', top_rated_books(books))
+
+
+if __name__ == '__main__':
+    main()

--- a/text_analysis.py
+++ b/text_analysis.py
@@ -1,0 +1,96 @@
+import csv
+import math
+import random
+from collections import Counter, defaultdict
+
+POSITIVE = {'good','great','excellent','amazing','wonderful','love','loved','like','masterpiece','outstanding'}
+NEGATIVE = {'bad','poor','terrible','awful','boring','hate','hated','dislike','mediocre','worst'}
+
+
+def load_books(path='Books.csv'):
+    books = []
+    with open(path, newline='', encoding='utf-8') as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            books.append(row)
+    return books
+
+
+def words_from_description(text):
+    return [w.strip('.,;!?:"\'()').lower() for w in text.split() if w]
+
+
+def word_frequencies_by_genre(books, top_n=20):
+    genre_words = defaultdict(Counter)
+    for b in books:
+        genre = b['genre'] or 'Unknown'
+        if b['description']:
+            words = words_from_description(b['description'])
+            genre_words[genre].update(words)
+    top = {g: words.most_common(top_n) for g, words in genre_words.items()}
+    return top
+
+
+def sentiment_by_genre(books):
+    scores = defaultdict(list)
+    for b in books:
+        genre = b['genre'] or 'Unknown'
+        if b['description']:
+            words = words_from_description(b['description'])
+            pos = sum(w in POSITIVE for w in words)
+            neg = sum(w in NEGATIVE for w in words)
+            scores[genre].append(pos - neg)
+    avg = {g: round(sum(vals)/len(vals), 3) for g, vals in scores.items() if vals}
+    return avg
+
+
+def simple_genre_classifier(books, train_ratio=0.8):
+    random.shuffle(books)
+    split = int(len(books)*train_ratio)
+    train, test = books[:split], books[split:]
+    word_counts = defaultdict(lambda: defaultdict(int))
+    genre_totals = Counter()
+    vocab = set()
+    for b in train:
+        genre = b['genre']
+        if not genre or not b['description']:
+            continue
+        words = words_from_description(b['description'])
+        genre_totals[genre] += 1
+        for w in words:
+            word_counts[genre][w] += 1
+            vocab.add(w)
+    genre_probs = {g: genre_totals[g]/sum(genre_totals.values()) for g in genre_totals}
+    def predict(desc):
+        words = words_from_description(desc)
+        scores = {}
+        for g in genre_totals:
+            total_words = sum(word_counts[g].values()) + len(vocab)
+            log_prob = math.log(genre_probs[g])
+            for w in words:
+                log_prob += math.log((word_counts[g][w] + 1) / total_words)
+            scores[g] = log_prob
+        return max(scores, key=scores.get)
+    correct = 0
+    total = 0
+    for b in test:
+        if not b['genre'] or not b['description']:
+            continue
+        pred = predict(b['description'])
+        if pred == b['genre']:
+            correct += 1
+        total += 1
+    accuracy = correct/total if total else None
+    return accuracy
+
+
+def main():
+    books = load_books()
+    freqs = word_frequencies_by_genre(books)
+    print('Word frequencies by genre (sample):', {g: words[:5] for g, words in freqs.items()})
+    print('Sentiment by genre:', sentiment_by_genre(books))
+    print('Genre classifier accuracy:', simple_genre_classifier(books))
+
+
+if __name__ == '__main__':
+    main()

--- a/time_series_analysis.py
+++ b/time_series_analysis.py
@@ -1,0 +1,50 @@
+import csv
+from collections import defaultdict
+
+
+def load_books(path='Books.csv'):
+    books = []
+    with open(path, newline='', encoding='utf-8') as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            books.append(row)
+    return books
+
+
+def to_int(value):
+    return int(value) if value and value.isdigit() else None
+
+
+def avg_pages_by_year(books):
+    pages_per_year = defaultdict(list)
+    for b in books:
+        year = b['published_date'][:4] if b['published_date'] else None
+        p = to_int(b['pages'])
+        if year and p is not None and year.isdigit():
+            pages_per_year[int(year)].append(p)
+    return {y: round(sum(v)/len(v), 2) for y, v in pages_per_year.items() if v}
+
+
+def genre_trends(books, top_n=5):
+    counts = defaultdict(lambda: defaultdict(int))
+    overall = defaultdict(int)
+    for b in books:
+        if b['genre']:
+            overall[b['genre']] += 1
+    top_genres = sorted(overall, key=overall.get, reverse=True)[:top_n]
+    for b in books:
+        year = b['published_date'][:4] if b['published_date'] else None
+        genre = b['genre']
+        if year and genre in top_genres and year.isdigit():
+            counts[genre][int(year)] += 1
+    return {g: dict(years) for g, years in counts.items()}
+
+
+def main():
+    books = load_books()
+    print('Average pages by year (sample):', list(avg_pages_by_year(books).items())[:10])
+    print('Genre trends (top):', genre_trends(books))
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- remove previous monolithic analysis scripts
- add EDA, popularity, NLP, time series, and clustering scripts as separate modules

## Testing
- `python3 eda_analysis.py | head -n 20`
- `python3 popularity_analysis.py | head -n 20`
- `python3 text_analysis.py | head -n 2 | cut -c -200`
- `python3 text_analysis.py | tail -n 1 | cut -c -200`
- `python3 time_series_analysis.py | head -n 1`
- `python3 time_series_analysis.py | tail -n 1 | cut -c -200`
- `python3 clustering_analysis.py | head -n 20`

------
https://chatgpt.com/codex/tasks/task_e_685cdf6e45588326a84c208101252b4f